### PR TITLE
Adding new default branches to point build towards the correct branches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,8 @@ notifications:
   email:
     - julia.elman@gsa.gov
     - maya.ben-ari@gsa.gov
+
+branches:
+  only:
+    - 18f-pages
+    - 18f-pages-staging


### PR DESCRIPTION
The default branch is currently set to `master`, of which does not exist anymore. This pull request updates the `.travis.yml` file to point to both the `18f-pages` and `18f-pages-staging` branches to run Travis off of.