### PR TITLE
Fix Travis to exclude vendor folder from build process

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ exclude:
 - CONTRIBUTING.md
 - ".sass-cache"
 - ".ruby-version"
+- vendor
 
 permalink: pretty
 


### PR DESCRIPTION
This fix is based off of the following issue/solve: https://github.com/jekyll/jekyll/issues/2938 and here: https://github.com/18F/hub/commit/29923e6d697da81116ff5cc11ca06ad933983b7a
