### PR TITLE
Adding basic main navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ url: https://pages.18f.gov/govt-wide-patternlibrary
 # Markdown config
 markdown: redcarpet
 highlighter: rouge
-name: Government-wide Pattern Library
+name: Government Wide Pattern Library
 exclude:
 - go
 - Gemfile
@@ -21,8 +21,8 @@ exclude:
 permalink: pretty
 
 repos:
-- name: Government-wide Pattern Library
-  description: Main repository for the government-wide pattern library.
+- name: Government Wide Pattern Library
+  description: Main repository for the Government Wide Pattern Library.
   url: https://github.com/18F/govt-wide-patternlibrary
 
 google_analytics_ua: UA-48605964-19

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,5 +1,5 @@
 	<!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
-	<script async="" id="_fed_an_ua_tag" src="assets/js/dap.min.js"></script>
+	<script async="" id="_fed_an_ua_tag" src="{{ site.baseurl }}/assets/js/dap.min.js"></script>
 
 	<!-- Google Analytics -->
 	<script>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,16 +1,20 @@
-<a id="skipnav" href="#main">Skip to main content</a>
-<nav class="navbar">
-	<a href="{{ site.baseurl }}/" class="branding">
-		Government Wide Pattern Library
-	</a>
-	<ul>
-		<li>
-			<a href="{{ site.baseurl }}/about/">About</a>
-		</li>
-		<li>
-			<a href="https://github.com/18F/govt-wide-patternlibrary/" target="_blank">
-			  View on Github
-			</a>
-			</li>
-	</ul>
-</nav>
+<header role="banner">
+  <div id="logo">
+    <a class="logo-link" href="{{ site.baseurl }}/" >
+      <h1 class="logo-link-heading">Government Wide Pattern Library</h1>
+    </a>
+  </div>
+  <a id="skipnav" href="#main">Skip to main content</a>
+  <nav class="navbar">
+    <ul>
+      <li>
+        <a href="{{ site.baseurl }}/about/">About</a>
+      </li>
+      <li>
+        <a href="https://github.com/18F/govt-wide-patternlibrary/" target="_blank">
+          View on Github
+        </a>
+        </li>
+    </ul>
+  </nav>
+</header>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,0 +1,15 @@
+<nav class="navbar">
+	<a href="{{ site.baseurl }}/" class="branding">
+		Government Wide Pattern Library
+	</a>
+	<ul>
+		<li>
+			<a href="{{ site.baseurl }}/about/">About</a>
+		</li>
+		<li>
+			<a href="https://github.com/18F/govt-wide-patternlibrary/" target="_blank">
+			  View on Github
+			</a>
+			</li>
+	</ul>
+</nav>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,3 +1,4 @@
+<a id="skipnav" href="#main-content">Skip to main content</a>
 <nav class="navbar">
 	<a href="{{ site.baseurl }}/" class="branding">
 		Government Wide Pattern Library

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,7 +1,7 @@
 <header role="banner">
   <div id="logo">
-    <a class="logo-link" href="{{ site.baseurl }}/" >
-      <h1 class="logo-link-heading">Government Wide Pattern Library</h1>
+    <a href="{{ site.baseurl }}/" >
+      <h1>Government Wide Pattern Library</h1>
     </a>
   </div>
   <a id="skipnav" href="#main">Skip to main content</a>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,6 +1,6 @@
 <header role="banner">
   <div id="logo">
-    <a accesskey="1" aria-label="Home" title="Home" href="{{ site.baseurl }}/" >
+    <a href="{{ site.baseurl }}/" accesskey="1" title="Home" aria-label="Home">
       <h1>Government Wide Pattern Library</h1>
     </a>
   </div>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,6 +1,6 @@
 <header role="banner">
   <div id="logo">
-    <a accesskey="1" href="{{ site.baseurl }}/" >
+    <a accesskey="1" aria-label="Home" title="Home" href="{{ site.baseurl }}/" >
       <h1>Government Wide Pattern Library</h1>
     </a>
   </div>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,4 +1,4 @@
-<a id="skipnav" href="#main-content">Skip to main content</a>
+<a id="skipnav" href="#main">Skip to main content</a>
 <nav class="navbar">
 	<a href="{{ site.baseurl }}/" class="branding">
 		Government Wide Pattern Library

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,6 +1,6 @@
 <header role="banner">
   <div id="logo">
-    <a href="{{ site.baseurl }}/" >
+    <a accesskey="1" href="{{ site.baseurl }}/" >
       <h1>Government Wide Pattern Library</h1>
     </a>
   </div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,2 +1,2 @@
-	<script src="assets/js/vendor/jquery.min.js"></script>
+	<script src="{{ site.baseurl }}/assets/js/vendor/jquery.min.js"></script>
 	

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,2 +1,3 @@
-<div class="nav-sidebar">
-</div>
+<aside class="sidenav">
+
+</aside>

--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -6,7 +6,6 @@
   </head>
 
   <body>
-    <div class="template-styleguide">
 
     	{% include navbar.html %}
   	
@@ -17,7 +16,6 @@
           {{ content }}
         </article>
       </div>
-    </div>
     {% include analytics.html %}
     {% include scripts.html %}
 

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -38,13 +38,16 @@ a#skipnav {
     }
 }
 
-nav.navbar {
+header[role="banner"] {
   background-color: $color-grey-900;
   height: 45px;
   line-height: 45px;
   a { color: white; }
-  .branding {
+  .logo-link-heading {
+    font-weight: normal;
     float: left;
+    line-height: 45px;
+    margin: 0;
     padding-left: 20px;
     font-size: $base-font-size * 1.25;
   }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -136,7 +136,7 @@ aside.sidenav {
   }
 }
 
-// Style Guide Content + Styles
+// Style Guide Content
 ///////////////////////////////////
 
 .styleguide-content {

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -1,156 +1,185 @@
 ---
 ---
 
+// Imports
+///////////////////////////////////
+
 @import 'lib/bourbon/bourbon';
 @import 'lib/neat/neat';
 @import 'core/grid-settings';
 @import 'core/defaults';
 @import 'core/utilities';
 
+// Variables
+///////////////////////////
+
 $width-nav-sidebar: 250px;
 
-.template-styleguide {
+
+// Navigation
+///////////////////////////////////
+
+nav.navbar {
+  background-color: $color-grey-900;
+  height: 45px;
+  line-height: 45px;
+  a { color: white; }
+  .branding {
+    float: left;
+    padding-left: 20px;
+    font-size: $base-font-size * 1.25;
+  }
+  ul {
+    float: right;
+    padding-right: 20px;
+    li { 
+      display: inline; 
+      margin-left: 15px;
+      font-family: $font-sans;
+    }
+  }
+}
+
+aside.sidenav {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
+  top: 45px;
   bottom: 0;
+  left: 0;
+  width: $width-nav-sidebar;
+  background-color: $color-grey-50;
+  border-right: 1px solid $color-grey-200;
+  padding: 1em 2em;
+  overflow: auto;
+  display: none;
+  .lt-ie9 & {
+    width: 25%;
+  }
 
-  .nav-sidebar {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    width: $width-nav-sidebar;
-    background-color: $color-grey-50;
-    border-right: 1px solid $color-grey-200;
-    padding: 1em 2em;
-    overflow: auto;
-    display: none;
-    .lt-ie9 & {
-      width: 25%;
-    }
-
-    @include media($tablet-up + $width-nav-sidebar) {
-      display: block;
-    }
-    
-    h1 {
-      font-weight: bold;
-      font-size: $h3-font-size;
-      padding-bottom: 1.1em;
-      border-bottom: 1px solid #000;
-    }
-    .link-h1 {
-      font-size: $h5-font-size;
-      font-weight: bold;
-    }
-    ul {
-      li {
-        padding: .25em 0;
-      }
-    }
-
-    ul ul {
-      padding-left: 1em;
-    }
-
-    a {
-      text-decoration: none;
-      &:hover {
-        text-decoration: underline;
-      }
+  @include media($tablet-up + $width-nav-sidebar) {
+    display: block;
+  }
+  
+  h1 {
+    font-weight: bold;
+    font-size: $h3-font-size;
+    padding-bottom: 1.1em;
+    border-bottom: 1px solid #000;
+  }
+  .link-h1 {
+    font-size: $h5-font-size;
+    font-weight: bold;
+  }
+  ul {
+    li {
+      padding: .25em 0;
     }
   }
 
-  .main-content {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    right: 0;
-    overflow: auto;
-    width: 100%;
+  ul ul {
+    padding-left: 1em;
+  }
 
+  a {
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+// Main Content
+///////////////////////////////////
+
+.main-content {
+  position: absolute;
+  top: 45px;
+  bottom: 0;
+  right: 0;
+  overflow: auto;
+  width: 100%;
+  padding: 1em 2em;
+  .lt-ie9 & {
+    width: 75%;
+  }
+
+  @include media($tablet-up + $width-nav-sidebar) {
+    width: calc(100% - #{$width-nav-sidebar});
     .lt-ie9 & {
       width: 75%;
     }
-
-    @include media($tablet-up + $width-nav-sidebar) {
-      width: calc(100% - #{$width-nav-sidebar});
-      .lt-ie9 & {
-        width: 75%;
-      }
-    }
   }
+}
 
-  .styleguide-content {
-    position: relative;
-    padding: 1em 2em;
-    > h2, > h3, > p, > ul, > ol {
-      max-width: 500px;
-    }
-    > h1 {
-      border-bottom: 1px solid #000;
-      padding-bottom: .5em;
-      &:not(:first-child) {
-        margin-top: 2em;
-      }
-    }
-    > h2, > h3 {
+// Style Guide Content + Styles
+///////////////////////////////////
+
+.styleguide-content {
+  position: relative;
+  padding: 0 2em 1em 2em;
+  > h2, > h3, > p, > ul, > ol {
+    max-width: 500px;
+  }
+  > h1 {
+    border-bottom: 1px solid #000;
+    padding-bottom: .5em;
+    &:not(:first-child) {
       margin-top: 2em;
     }
   }
-
-  //Pattern Preview Boxes
-  .preview {
-    @include clearfix();
-    background-color: #fff;
-    margin: {
-      top: 2em;
-      bottom: 2em;
-    }
-    padding: 1em $site-margins;
-    border: 1px solid $color-grey-200;
-    .is-peripheral {
-      opacity: .2;
-    }
+  > h2, > h3 {
+    margin-top: 2em;
   }
+}
 
-  //Code Sample Boxes
-  .code-sample {
-    @include clearfix();
-    border: 1px solid $color-grey-200;
-    background-color: $color-grey-50;
+//Pattern Preview Boxes
+.preview {
+  @include clearfix();
+  background-color: #fff;
+  margin: {
+    top: 2em;
+    bottom: 2em;
+  }
+  padding: 1em $site-margins;
+  border: 1px solid $color-grey-200;
+  .is-peripheral {
+    opacity: .2;
+  }
+}
 
-    &.is-open {
-      .button-toggle:before {
-        content: 'Hide code';
-      }
-      pre {
-        display: block;
-      }
-    }
-    .button-toggle {
-      font-size: $small-font-size;
-      display: block;
-      padding: .5em $site-margins;
-      text-decoration: underline;
-      &:before {
-        content: 'Show code';
-      }
+//Code Sample Boxes
+.code-sample {
+  @include clearfix();
+  border: 1px solid $color-grey-200;
+  background-color: $color-grey-50;
+
+  &.is-open {
+    .button-toggle:before {
+      content: 'Hide code';
     }
     pre {
-      display: none;
-      background-color: transparent;
-      overflow-y: hidden;
-      code {
-        background-color: transparent;
-      }     
+      display: block;
     }
   }
-
-  .preview + .code-sample {
-    margin-top: -2em;
-    border-top: 0px;
+  .button-toggle {
+    font-size: $small-font-size;
+    display: block;
+    padding: .5em $site-margins;
+    text-decoration: underline;
+    &:before {
+      content: 'Show code';
+    }
   }
+  pre {
+    display: none;
+    background-color: transparent;
+    overflow-y: hidden;
+    code {
+      background-color: transparent;
+    }     
+  }
+}
+
+.preview + .code-sample {
+  margin-top: -2em;
+  border-top: 0px;
 }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -19,6 +19,25 @@ $width-nav-sidebar: 250px;
 // Navigation
 ///////////////////////////////////
 
+a#skipnav {
+    padding: 10px 15px;
+    position: absolute;
+    top: -40px;
+    left: 0px;
+    color: $color-grey-900;
+    background: transparent;
+    @include transition(top 1s ease-out, background 1s linear);
+    z-index: 100;
+    &:focus {
+      position: absolute;
+      left: 0px;
+      top: 0px;
+      background: white;
+      outline: 0;
+      @include transition(top .1s ease-in, background .5s linear);
+    }
+}
+
 nav.navbar {
   background-color: $color-grey-900;
   height: 45px;

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -41,7 +41,7 @@ header[role="banner"] {
   height: 45px;
   line-height: 45px;
   a { color: white; }
-  .logo-link-heading {
+  h1 {
     font-weight: normal;
     float: left;
     line-height: 45px;

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -60,7 +60,7 @@ header[role="banner"] {
       margin-left: 15px;
       font-family: $font-sans;
     }
-    @include media($tablet-up + $width-nav-sidebar) {
+    @include media($mobile-up) {
       display: block;
     }
   }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -51,10 +51,14 @@ nav.navbar {
   ul {
     float: right;
     padding-right: 20px;
+    display: none;
     li { 
       display: inline; 
       margin-left: 15px;
       font-family: $font-sans;
+    }
+    @include media($tablet-up + $width-nav-sidebar) {
+      display: block;
     }
   }
 }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -10,12 +10,12 @@
 @import 'core/utilities';
 
 
-// Variables
+// Variables -------------- //
 
 $width-nav-sidebar: 250px;
 
 
-// Navigation
+// Navigation ------------- //
 
 a#skipnav {
     padding: 10px 15px;
@@ -112,7 +112,7 @@ aside.sidenav {
 }
 
 
-// Main Content
+// Main Content --------- //
 
 .main-content {
   position: absolute;
@@ -134,8 +134,7 @@ aside.sidenav {
   }
 }
 
-
-// Style Guide Content
+// Style Guide Content -------- //
 
 .styleguide-content {
   position: relative;
@@ -155,7 +154,7 @@ aside.sidenav {
   }
 }
 
-// Pattern Preview Boxes
+// Pattern Preview Boxes -------- //
 
 .preview {
   @include clearfix();
@@ -171,7 +170,7 @@ aside.sidenav {
   }
 }
 
-// Code Sample Boxes
+// Code Sample Boxes --------- //
 
 .code-sample {
   @include clearfix();

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -1,8 +1,7 @@
 ---
 ---
 
-// Imports
-///////////////////////////////////
+// Imports -------------- //
 
 @import 'lib/bourbon/bourbon';
 @import 'lib/neat/neat';
@@ -10,14 +9,13 @@
 @import 'core/defaults';
 @import 'core/utilities';
 
+
 // Variables
-///////////////////////////
 
 $width-nav-sidebar: 250px;
 
 
 // Navigation
-///////////////////////////////////
 
 a#skipnav {
     padding: 10px 15px;
@@ -113,8 +111,8 @@ aside.sidenav {
   }
 }
 
+
 // Main Content
-///////////////////////////////////
 
 .main-content {
   position: absolute;
@@ -136,8 +134,8 @@ aside.sidenav {
   }
 }
 
+
 // Style Guide Content
-///////////////////////////////////
 
 .styleguide-content {
   position: relative;
@@ -157,7 +155,8 @@ aside.sidenav {
   }
 }
 
-//Pattern Preview Boxes
+// Pattern Preview Boxes
+
 .preview {
   @include clearfix();
   background-color: #fff;
@@ -172,7 +171,8 @@ aside.sidenav {
   }
 }
 
-//Code Sample Boxes
+// Code Sample Boxes
+
 .code-sample {
   @include clearfix();
   border: 1px solid $color-grey-200;

--- a/pages/about.html
+++ b/pages/about.html
@@ -1,0 +1,9 @@
+---
+permalink: /about/
+layout: default
+title: About
+---
+
+<h1>About</h1>
+
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>

--- a/pages/about.md
+++ b/pages/about.md
@@ -1,9 +1,0 @@
----
-permalink: /about/
-layout: default
-title: About
----
-
-## About
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/pages/about.md
+++ b/pages/about.md
@@ -1,5 +1,9 @@
 ---
-permalink: /about/
+permalink: about/
 layout: default
 title: About
 ---
+
+## About
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/pages/about.md
+++ b/pages/about.md
@@ -1,5 +1,5 @@
 ---
-permalink: about/
+permalink: /about/
 layout: default
 title: About
 ---

--- a/pages/index.html
+++ b/pages/index.html
@@ -4,11 +4,11 @@ layout: styleguide
 title: Government-wide Pattern Library
 ---
 
-# About this Guide
+<h1>About this Guide</h1> 
 
-This style guide is meant for as reference for designers, developers, as well as anyone else interested in the design and frontend concepts that make up the building blocks of federal government websites.
+<p>This style guide is meant for as reference for designers, developers, as well as anyone else interested in the design and frontend concepts that make up the building blocks of federal government websites.</p>
 
-# Component name
+<h1>Component name</h1>
 
 <div class="preview">
 <!-- Add HTML markup for example here -->
@@ -25,36 +25,35 @@ This style guide is meant for as reference for designers, developers, as well as
   </div>  
 </div> 
 
-# Visual Style
+<h1>Visual Style</h1>
 
 {% for visual in site.visual %}
-## {{ visual.title }}
-{{ visual.content }}
+<h2>{{ visual.title }}</h2> 
+<p>{{ visual.content }}</p>
 {% endfor %}
 
-# Layout System
+<h1>Layout System</h1>
 
 {% for layout in site.layout-system %}
-## {{ layout.title }}
-
-{{ layout.content }}
+<h2>{{ layout.title }}</h2>
+<p>{{ layout.content }}</p>
 {% endfor %}
 
 {% assign components = site.patterns | where:"type","component" %}
 {% assign elements = site.patterns | where:"type","element" %}
 
-# Elements
+<h1>Elements</h1>
 
 {% for element in elements %}
-## {{ element.title }}
-{{ element.content }}
+<h2>{{ element.title }}</h2>
+<p>{ element.content }}</p>{
 {% endfor %}
 
 # Components
 
 {% for component in components %}
-## {{ component.title }}
-{{ component.content }}
+<h2>{{ component.title }}</h2>
+<p>{{ component.content }}</p>
 {% endfor %}
 
 <a href="#">Text link</a>

--- a/pages/index.html
+++ b/pages/index.html
@@ -25,37 +25,8 @@ title: Government-wide Pattern Library
   </div>  
 </div> 
 
-<h1>Visual Style</h1>
+{% include_relative visual-style.html %}
 
-{% for visual in site.visual %}
-<h2>{{ visual.title }}</h2> 
-<p>{{ visual.content }}</p>
-{% endfor %}
+{% include_relative layout-system.html %}
 
-<h1>Layout System</h1>
-
-{% for layout in site.layout-system %}
-<h2>{{ layout.title }}</h2>
-<p>{{ layout.content }}</p>
-{% endfor %}
-
-{% assign components = site.patterns | where:"type","component" %}
-{% assign elements = site.patterns | where:"type","element" %}
-
-<h1>Elements</h1>
-
-{% for element in elements %}
-<h2>{{ element.title }}</h2>
-<p>{ element.content }}</p>{
-{% endfor %}
-
-# Components
-
-{% for component in components %}
-<h2>{{ component.title }}</h2>
-<p>{{ component.content }}</p>
-{% endfor %}
-
-<a href="#">Text link</a>
-
-<button type="button">Button link</button>
+{% include_relative patterns.html %}

--- a/pages/index.html
+++ b/pages/index.html
@@ -25,8 +25,38 @@ title: Government Wide Pattern Library
   </div>  
 </div> 
 
-{% include_relative visual-style.html %}
+<h1>Visual Style</h1>
 
-{% include_relative layout-system.html %}
+{% for visual in site.visual %}
+	<h2>{{ visual.title }}</h2>
+	<p>{{ visual.content }}</p>
+{% endfor %}
 
-{% include_relative patterns.html %}
+<h1>Layout System</h1> 
+
+{% for layout in site.layout-system %}
+	<h2>{{ layout.title }}</h2>
+	<p>{{ layout.content }}</p>
+{% endfor %}
+
+{% assign components = site.patterns | where:"type","component" %}
+{% assign elements = site.patterns | where:"type","element" %}
+
+<h1>Elements</h1>
+
+{% for element in elements %}
+	<h2>{{ element.title }}</h2>
+	<p>{{ element.content }}</p>
+{% endfor %}
+
+
+<h1>Components</h1>
+
+{% for component in components %}
+	<h2>{{ component.title }}</h2>
+	<p>{{ component.content }}</p>
+{% endfor %}
+
+<a href="#">Text link</a>
+
+<button type="button">Button link</button>

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,7 +1,7 @@
 ---
 permalink: /
 layout: styleguide
-title: Government-wide Pattern Library
+title: Government Wide Pattern Library
 ---
 
 <h1>About this Guide</h1> 

--- a/pages/layout-system.html
+++ b/pages/layout-system.html
@@ -4,10 +4,9 @@ layout: styleguide
 title: Layout System
 ---
 
-# Layout System
+<h1>Layout System</h1> 
 
 {% for layout in site.layout-system %}
-## {{ layout.title }}
-
-{{ layout.content }}
+	<h2>{{ layout.title }}</h2>
+	<p>{{ layout.content }}</p>
 {% endfor %}

--- a/pages/patterns.html
+++ b/pages/patterns.html
@@ -21,3 +21,7 @@ title: Patterns
 	<h2>{{ component.title }}</h2>
 	<p>{{ component.content }}</p>
 {% endfor %}
+
+<a href="#">Text link</a>
+
+<button type="button">Button link</button>

--- a/pages/patterns.html
+++ b/pages/patterns.html
@@ -7,17 +7,17 @@ title: Patterns
 {% assign components = site.patterns | where:"type","component" %}
 {% assign elements = site.patterns | where:"type","element" %}
 
-# Elements
+<h1>Elements</h1>
 
 {% for element in elements %}
-## {{ element.title }}
-{{ element.content }}
+	<h2>{{ element.title }}</h2>
+	<p>{{ element.content }}</p>
 {% endfor %}
 
 
-# Components
+<h1>Components</h1>
 
 {% for component in components %}
-## {{ component.title }}
-{{ component.content }}
+	<h2>{{ component.title }}</h2>
+	<p>{{ component.content }}</p>
 {% endfor %}

--- a/pages/visual-style.html
+++ b/pages/visual-style.html
@@ -4,9 +4,9 @@ layout: styleguide
 title: Visual Style
 ---
 
-# Visual Style
+<h1>Visual Style</h1>
 
 {% for visual in site.visual %}
-## {{ visual.title }}
-{{ visual.content }}
+	<h2>{{ visual.title }}</h2>
+	<p>{{ visual.content }}</p>
 {% endfor %}


### PR DESCRIPTION
This pull request includes the main navigation for the pattern library, as outlined in the desktop wireframes #21. A few other things to note in this pull request:

- Added a skipnav for 508 accessibility
- Changed /pages files from `.md` to `.html` and replaced markup, fixes #50 
- Moved references to pattern library sections in index.html and created a more DRY approach

NOTE: This pull request does not include the slide out nav, as we will most likely do this once the side navigation has been laid out.
