### PR TITLE
Removed 'fix' for font smoothing from _typography.scss

### DIFF
--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -5,7 +5,6 @@ html {
 
 body {
   font-size: $base-font-size;
-  -webkit-font-smoothing: antialiased;
 }
 
 p {


### PR DESCRIPTION
Please stop fixing font smoothing:
http://usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/