### PR TITLE
Moving skip nav link to fix link/breakage.

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,10 +1,10 @@
+<a id="skipnav" href="#main">Skip to main content</a>
 <header role="banner">
   <div id="logo">
     <a href="{{ site.baseurl }}/" accesskey="1" title="Home" aria-label="Home">
       <h1>Government Wide Pattern Library</h1>
     </a>
   </div>
-  <a id="skipnav" href="#main">Skip to main content</a>
   <nav class="navbar">
     <ul>
       <li>


### PR DESCRIPTION
There is currently an conflict when trying to click on the "Government Wide Pattern Library" and the skip nav. Due to the changes done in 6bec201079d96ef14c05c533cbbafa2ae4562b13, the positioning on of the skip nav overlays when trying to click on that link. This PR solves the issue by moving the skip nav link directly underneath the `<body>` tag.