### PR TITLE
Hide sidebar navigation items

### DIFF
--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -5,7 +5,7 @@
     {% include head.html %}
   </head>
 
-  <body>
+  <body class="{{ site.title }}">
 
     	{% include navbar.html %}
   	

--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -5,7 +5,7 @@
     {% include head.html %}
   </head>
 
-  <body class="{{ site.title }}">
+  <body class="{{ page.slug }}">
 
     	{% include navbar.html %}
   	

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -184,7 +184,7 @@ header[role="banner"] {
     display: block;
   }
 }
-.componentss .sidenav .components-list {
+.components .sidenav .components-list {
   ul {
     display: block;
   }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -147,8 +147,7 @@ header[role="banner"] {
       margin: 0;
     }  
     ul {
-      color: $color-main;
-      }      
+      color: $color-main;      
       ul {
         display: none;
         padding: 0;        
@@ -185,7 +184,7 @@ header[role="banner"] {
     display: block;
   }
 }
-.components .sidenav .components-list {
+.componentss .sidenav .components-list {
   ul {
     display: block;
   }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -148,9 +148,10 @@ header[role="banner"] {
     }  
     ul {
       color: $color-main;
+
       ul {
         display: none;
-        padding: 0;
+        padding: 0;        
         li {
           padding-left: 1em;          
         }
@@ -168,6 +169,7 @@ header[role="banner"] {
     }
   }
 }
+
 
 
 // Main Content --------- //

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -148,7 +148,7 @@ header[role="banner"] {
     }  
     ul {
       color: $color-main;
-
+      }      
       ul {
         display: none;
         padding: 0;        
@@ -170,7 +170,26 @@ header[role="banner"] {
   }
 }
 
-
+.visual-style .sidenav .visual-style-list {
+  ul {
+    display: block;
+  }
+}
+.layout-system .sidenav .layout-systems-list {
+  ul {
+    display: block;
+  }
+}
+.elements .sidenav .elements-list {
+  ul {
+    display: block;
+  }
+}
+.componentss .sidenav .components-list {
+  ul {
+    display: block;
+  }
+} 
 
 // Main Content --------- //
 

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -233,6 +233,12 @@ header[role="banner"] {
   }
 }
 
+// ***** TEMPORARY FIX - REMOVE AFTER CONTENT IS ADDED ***** //
+
+.styleguide-content {
+  padding-bottom: 25em;
+}
+
 // Pattern Preview Boxes -------- //
 
 .preview {

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -149,6 +149,7 @@ header[role="banner"] {
     ul {
       color: $color-main;
       ul {
+        display: none;
         padding: 0;
         li {
           padding-left: 1em;          

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -185,7 +185,7 @@ header[role="banner"] {
     display: block;
   }
 }
-.componentss .sidenav .components-list {
+.components .sidenav .components-list {
   ul {
     display: block;
   }

--- a/pages/components.html
+++ b/pages/components.html
@@ -2,6 +2,7 @@
 permalink: /components/
 layout: styleguide
 title: Components
+slug: components
 ---
 
 <h1>Components</h1>

--- a/pages/elements.html
+++ b/pages/elements.html
@@ -2,6 +2,7 @@
 permalink: /elements/
 layout: styleguide
 title: Elements
+slug: elements
 ---
 
 <h1>Elements</h1>

--- a/pages/layout-system.html
+++ b/pages/layout-system.html
@@ -2,6 +2,7 @@
 permalink: /layout-system/
 layout: styleguide
 title: Layout System
+slug: layout-system
 ---
 
 <h1>Layout System</h1> 

--- a/pages/visual-style.html
+++ b/pages/visual-style.html
@@ -2,6 +2,7 @@
 permalink: /visual-style/
 layout: styleguide
 title: Visual Style
+slug: visual-style
 ---
 
 <h1>Visual Style</h1>


### PR DESCRIPTION
This hides sidebar navigation items _not_ in the current page. It will only show the child list items for the page it's on.

This resolves one of the bullet points in https://github.com/18F/govt-wide-patternlibrary/issues/21

This is what it looks like when you're on the Components page:

![screen shot 2015-06-22 at 7 09 34 pm](https://cloud.githubusercontent.com/assets/5249443/8297436/383983d0-1912-11e5-9ef6-42792ac35583.png)
