### PR TITLE
Fix h2 placement

### DIFF
--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -229,7 +229,7 @@ header[role="banner"] {
     }
   }
   > h2, > h3 {
-    margin-top: 2em;
+    padding-top: 52px;
   }
 }
 

--- a/pages/components.html
+++ b/pages/components.html
@@ -8,7 +8,6 @@ slug: components
 <h1>Components</h1>
 
 {% for component in site.components %}
-  <a class="anchor" id="{{ component.title | slugify }}"></a>
-  <h2>{{ component.title }}</h2>
+  <h2 id="{{ component.title | slugify }}">{{ component.title }}</h2>
   <p>{{ component.content }}</p>
 {% endfor %}

--- a/pages/elements.html
+++ b/pages/elements.html
@@ -8,7 +8,6 @@ slug: elements
 <h1>Elements</h1>
 
 {% for element in site.elements %}
-  <a class="anchor" id="{{ element.title | slugify }}"></a>
-  <h2>{{ element.title }}</h2>
+  <h2 id="{{ element.title | slugify }}">{{ element.title }}</h2>
   <p>{{ element.content }}</p>
 {% endfor %}

--- a/pages/layout-system.html
+++ b/pages/layout-system.html
@@ -8,7 +8,6 @@ slug: layout-system
 <h1>Layout System</h1> 
 
 {% for layout in site.layout-system %}
-  <a class="anchor" id="{{ layout.title | slugify }}"></a>
-  <h2>{{ layout.title }}</h2>
+  <h2 id="{{ layout.title | slugify }}">{{ layout.title }}</h2>
   <p>{{ layout.content }}</p>
 {% endfor %}

--- a/pages/visual-style.html
+++ b/pages/visual-style.html
@@ -8,7 +8,6 @@ slug: visual-style
 <h1>Visual Style</h1>
 
 {% for visual in site.visual %}
-  <a class="anchor" id="{{ visual.title | slugify }}"></a>
-  <h2>{{ visual.title }}</h2>
+  <h2 id="{{ visual.title | slugify }}">{{ visual.title }}</h2>
   <p>{{ visual.content }}</p>
 {% endfor %}


### PR DESCRIPTION
This fixes the issue where the placement of the h2 heading was not falling in the correct place. This resolves: https://github.com/18F/govt-wide-patternlibrary/issues/63

This is what it looks like:

![heading-fix](https://cloud.githubusercontent.com/assets/5249443/8316900/af1ecbda-19ae-11e5-9781-238cc8fb0299.png)
