### PR TITLE
Add typography content

### DIFF
--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -3,7 +3,7 @@
 
 <aside class="sidenav" id="menu-content">
   <nav>
-    <ul class="unstyled-list">
+    <ul class="usa-unstyled-list">
       <li class="tablet-only">
         <a href="{{ site.baseurl }}/">Home</a>
       </li>
@@ -14,7 +14,7 @@
         <h2>
           <a href="{{ site.baseurl }}/visual-style/">Visual Style</a>
         </h2>
-        <ul class="unstyled-list">
+        <ul class="usa-unstyled-list">
           {% for visual in site.visual %}
             <li>
               <a class="secondary-sidenav-link" href="{{ site.baseurl }}/visual-style/#{{ visual.title | slugify }}">{{ visual.title }}</a>
@@ -26,7 +26,7 @@
         <h2>
           <a href="{{ site.baseurl }}/layout-system/">Layout System</a>
         </h2>
-        <ul class="unstyled-list">
+        <ul class="usa-unstyled-list">
           {% for layout in site.layout-system %}
           <li>
             <a class="secondary-sidenav-link" href="{{ site.baseurl }}/layout-system/#{{ layout.title | slugify }}">{{ layout.title }}</a>
@@ -38,7 +38,7 @@
         <h2>
           <a href="{{ site.baseurl }}/elements/">Elements</a>
         </h2>
-        <ul class="unstyled-list">
+        <ul class="usa-unstyled-list">
           {% for element in site.elements %}
           <li>
             <a class="secondary-sidenav-link" href="{{ site.baseurl }}/elements/#{{ element.title | slugify }}">{{ element.title }}</a>
@@ -50,7 +50,7 @@
         <h2>
           <a href="{{ site.baseurl }}/components/">Components</a>
         </h2>
-        <ul class="unstyled-list">
+        <ul class="usa-unstyled-list">
           {% for component in site.components %}
           <li>
             <a class="secondary-sidenav-link" href="{{ site.baseurl }}/components/#{{ component.title | slugify }}">{{ component.title }}</a>

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -3,7 +3,7 @@
 
 <aside class="sidenav" id="menu-content">
   <nav>
-    <ul>
+    <ul class="unstyled-list">
       <li class="tablet-only">
         <a href="{{ site.baseurl }}/">Home</a>
       </li>
@@ -14,7 +14,7 @@
         <h2>
           <a href="{{ site.baseurl }}/visual-style/">Visual Style</a>
         </h2>
-        <ul>
+        <ul class="unstyled-list">
           {% for visual in site.visual %}
             <li>
               <a class="secondary-sidenav-link" href="{{ site.baseurl }}/visual-style/#{{ visual.title | slugify }}">{{ visual.title }}</a>
@@ -26,7 +26,7 @@
         <h2>
           <a href="{{ site.baseurl }}/layout-system/">Layout System</a>
         </h2>
-        <ul>
+        <ul class="unstyled-list">
           {% for layout in site.layout-system %}
           <li>
             <a class="secondary-sidenav-link" href="{{ site.baseurl }}/layout-system/#{{ layout.title | slugify }}">{{ layout.title }}</a>
@@ -38,7 +38,7 @@
         <h2>
           <a href="{{ site.baseurl }}/elements/">Elements</a>
         </h2>
-        <ul>
+        <ul class="unstyled-list">
           {% for element in site.elements %}
           <li>
             <a class="secondary-sidenav-link" href="{{ site.baseurl }}/elements/#{{ element.title | slugify }}">{{ element.title }}</a>
@@ -50,7 +50,7 @@
         <h2>
           <a href="{{ site.baseurl }}/components/">Components</a>
         </h2>
-        <ul>
+        <ul class="unstyled-list">
           {% for component in site.components %}
           <li>
             <a class="secondary-sidenav-link" href="{{ site.baseurl }}/components/#{{ component.title | slugify }}">{{ component.title }}</a>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -20,12 +20,26 @@ title: Typography
 
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 
-
   <!-- Links title -->
   <h3>Links</h3>
 
   <p>This is <a href="#">linked text</a></p>
   <p>This is <a href="#">linked text</a></p>
+
+  <!-- Lists title -->
+  <h3>Lists</h3>
+
+  <ul>
+    <li>Unordered list item</li>
+    <li>Unordered list item</li>
+    <li>Unordered list item</li>
+  </ul>
+
+  <ol>
+    <li>Ordered list item</li>
+    <li>Ordered list item</li>
+    <li>Ordered list item</li>
+  </ol>
 
   <img src="{{ site.baseurl }}/assets/img/static/Typography_UI_v1.png">
 </div>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -25,7 +25,7 @@ title: Typography
   <h3>Links</h3>
 
   <p>This is <a href="#">linked text</a></p>
-  <p>This is <a href="#">linked text</a></p>
+  <p>This is <a class="usa-link" href="#">linked text</a></p>
 
   <!-- Lists title -->
   <h3>Lists</h3>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -25,7 +25,7 @@ title: Typography
   <h3>Links</h3>
 
   <p>This is <a href="#">linked text</a> for body copy</p>
-  <p class="sans">This is <a href="#">linked text</a> for everything else</p>
+  <p class="usa-sans">This is <a href="#">linked text</a> for everything else</p>
 
   <!-- Lists title -->
   <h3>Lists</h3>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -5,11 +5,11 @@ title: Typography
 
 <div class="preview">
   <!-- Add HTML markup for example here -->
-  <h1>Heading Level 1</h1>
-  <h2>Heading Level 2</h2>
-  <h3>Heading Level 3</h3>
-  <h4>Heading Level 4</h4>
-  <h5>Heading Level 5</h5>
+  <h1>Heading 1 in 36px in Source Sans Pro 700</h1>
+  <h2>Heading 2 in 24px in Source Sans Pro 700</h2>
+  <h3>Heading 3 in 19px in Source Sans Pro 700</h3>
+  <h4>Heading 4 in 16px in Source Sans Pro 700</h4>
+  <h5>Heading 5 in 14px in Source Sans Pro 700</h5>
 
   <img src="{{ site.baseurl }}/assets/img/static/Typography_UI_v1.png">
 </div>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -5,6 +5,12 @@ title: Typography
 
 <div class="preview">
   <!-- Add HTML markup for example here -->
+  <h1>Heading Level 1</h1>
+  <h2>Heading Level 2</h2>
+  <h3>Heading Level 3</h3>
+  <h4>Heading Level 4</h4>
+  <h5>Heading Level 5</h5>
+
   <img src="{{ site.baseurl }}/assets/img/static/Typography_UI_v1.png">
 </div>
 

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -5,11 +5,20 @@ title: Typography
 
 <div class="preview">
   <!-- Add HTML markup for example here -->
+
+  <!-- Heading title -->
+  <h3>Headings</h3>
+
   <h1>Heading 1 in 36px in Source Sans Pro 700</h1>
   <h2>Heading 2 in 24px in Source Sans Pro 700</h2>
   <h3>Heading 3 in 19px in Source Sans Pro 700</h3>
   <h4>Heading 4 in 16px in Source Sans Pro 700</h4>
   <h5>Heading 5 in 14px in Source Sans Pro 700</h5>
+
+  <!-- Body title -->
+  <h3>Body</h3>
+
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 
   <img src="{{ site.baseurl }}/assets/img/static/Typography_UI_v1.png">
 </div>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -9,6 +9,7 @@ title: Typography
   <!-- Heading title -->
   <h3>Headings</h3>
 
+  <h3 class="usa-display">Display 48px in Source Sans Pro 700</h3>
   <h1>Heading 1 in 36px in Source Sans Pro 700</h1>
   <h2>Heading 2 in 24px in Source Sans Pro 700</h2>
   <h3>Heading 3 in 19px in Source Sans Pro 700</h3>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -25,7 +25,7 @@ title: Typography
   <h3>Links</h3>
 
   <p>This is <a href="#">linked text</a> for body copy</p>
-  <p>This is <a class="usa-link" href="#">linked text</a> for everything else</p>
+  <p class="sans">This is <a href="#">linked text</a> for everything else</p>
 
   <!-- Lists title -->
   <h3>Lists</h3>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -24,8 +24,8 @@ title: Typography
   <!-- Links title -->
   <h3>Links</h3>
 
-  <p>This is <a href="#">linked text</a></p>
-  <p>This is <a class="usa-link" href="#">linked text</a></p>
+  <p>This is <a href="#">linked text</a> for body copy</p>
+  <p>This is <a class="usa-link" href="#">linked text</a> for everything else</p>
 
   <!-- Lists title -->
   <h3>Lists</h3>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -20,6 +20,13 @@ title: Typography
 
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 
+
+  <!-- Links title -->
+  <h3>Links</h3>
+
+  <p>This is <a href="#">linked text</a></p>
+  <p>This is <a href="#">linked text</a></p>
+
   <img src="{{ site.baseurl }}/assets/img/static/Typography_UI_v1.png">
 </div>
 

--- a/assets/_scss/core/_defaults.scss
+++ b/assets/_scss/core/_defaults.scss
@@ -16,9 +16,10 @@ $h6-font-size:      rem(12px) !default;
 $base-line-height:    1.5em !default;
 $heading-line-height: 1.3em !default;
 
-$font-sans:       'Source Sans Pro', 'Helvetica', 'Arial', sans-serif !default;
-$font-serif:      'Georgia', 'Times New Roman', serif;
+$font-sans:        'Source Sans Pro', 'Helvetica', 'Arial', sans-serif !default;
+$font-serif:       'Georgia', 'Times New Roman', serif;
 
+$font-bold:         700 !default;
 
 // Color
 $color-grey-50:     #fafafa !default;

--- a/assets/_scss/core/_defaults.scss
+++ b/assets/_scss/core/_defaults.scss
@@ -34,9 +34,6 @@ $color-grey-900:    #212121 !default;
 
 $color-base-link:   #000000 !default;
 
-$color-main:        #0071bc !default;
-$color-main-dark:   #00609f !default;
-
 // Mobile First Breakpoints
 $mobile-up:         481px !default;
 $tablet-up:         600px !default;

--- a/assets/_scss/core/_variables.scss
+++ b/assets/_scss/core/_variables.scss
@@ -15,6 +15,8 @@ $heading-line-height: 1.3em;
 $font-sans:       'Source Sans Pro', 'Helvetica', 'Arial', sans-serif;
 $font-serif:      'Georgia', 'Times New Roman', serif;
 
+$font-bold:         700;
+
 // Color
 $color-grey-50:     #fafafa;
 $color-grey-100:    #f5f5f5;

--- a/assets/_scss/core/_variables.scss
+++ b/assets/_scss/core/_variables.scss
@@ -29,9 +29,6 @@ $color-grey-900:    #212121;
 
 $color-base-link:   #000000;
 
-$color-main:        #0071bc;
-$color-main-dark:   #00609f;
-
 // Mobile First Breakpoints
 $mobile-up:         481px;
 $tablet-up:         600px;

--- a/assets/_scss/elements/_list.scss
+++ b/assets/_scss/elements/_list.scss
@@ -1,24 +1,29 @@
+// Make lists unstyled by default
 ul, ol {
-  margin: 0;  
-  list-style-type: none;  
-  padding-left: 2em;
-  margin: {
-    top: 2em;
-    bottom: 2em;
-  }
-  li {
-    line-height: $base-line-height;
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+article {
+  ul, ol {
+    padding-left: 2em;
     margin: {
-      top: 1em;
-      bottom: 1em;
+      top: 2em;
+      bottom: 2em;
+    }
+    li {
+      line-height: $base-line-height;
+      margin: {
+        top: 1em;
+        bottom: 1em;
+      }
     }
   }
-}
-
-ul {
-  list-style-type: square;
-}
-
-ol {
-  list-style-type: decimal;
+  ul {
+    list-style-type: square;
+  }
+  ol {
+    list-style-type: decimal;
+  }
 }

--- a/assets/_scss/elements/_list.scss
+++ b/assets/_scss/elements/_list.scss
@@ -1,29 +1,24 @@
-// Make lists unstyled by default
 ul, ol {
-  margin: 0;
-  padding: 0;
-  list-style-type: none;
+  margin: 0;  
+  list-style-type: none;  
+  padding-left: 2em;
+  margin: {
+    top: 2em;
+    bottom: 2em;
+  }
+  li {
+    line-height: $base-line-height;
+    margin: {
+      top: 1em;
+      bottom: 1em;
+    }
+  }
 }
 
-article {
-  ul, ol {
-    padding-left: 2em;
-    margin: {
-      top: 2em;
-      bottom: 2em;
-    }
-    li {
-      line-height: $base-line-height;
-      margin: {
-        top: 1em;
-        bottom: 1em;
-      }
-    }
-  }
-  ul {
-    list-style-type: square;
-  }
-  ol {
-    list-style-type: decimal;
-  }
+ul {
+  list-style-type: square;
+}
+
+ol {
+  list-style-type: decimal;
 }

--- a/assets/_scss/elements/_list.scss
+++ b/assets/_scss/elements/_list.scss
@@ -20,6 +20,7 @@ ol {
 }
 
 // Unstyled lists
+
 .unstyled-list {
   margin: 0;
   padding: 0;

--- a/assets/_scss/elements/_list.scss
+++ b/assets/_scss/elements/_list.scss
@@ -1,8 +1,8 @@
 ul, ol {
-  padding-left: 2em;
   margin: {
     top: 2em;
     bottom: 2em;
+  padding-left: 2em;
   }
   li {
     line-height: $base-line-height;
@@ -12,9 +12,11 @@ ul, ol {
     }
   }
 }
+
 ul {
   list-style-type: square;
 }
+
 ol {
   list-style-type: decimal;
 }

--- a/assets/_scss/elements/_list.scss
+++ b/assets/_scss/elements/_list.scss
@@ -4,6 +4,7 @@ ul, ol {
     bottom: 2em;
   padding-left: 2em;
   }
+
   li {
     line-height: $base-line-height;
     margin: {
@@ -27,6 +28,7 @@ ol {
   margin: 0;
   padding: 0;
   list-style-type: none;
+  
   li {
     margin: 0;
   }

--- a/assets/_scss/elements/_list.scss
+++ b/assets/_scss/elements/_list.scss
@@ -1,29 +1,30 @@
-// Make lists unstyled by default
 ul, ol {
+  padding-left: 2em;
+  margin: {
+    top: 2em;
+    bottom: 2em;
+  }
+  li {
+    line-height: $base-line-height;
+    margin: {
+      top: 1em;
+      bottom: 1em;
+    }
+  }
+}
+ul {
+  list-style-type: square;
+}
+ol {
+  list-style-type: decimal;
+}
+
+// Unstyled lists
+.unstyled-list {
   margin: 0;
   padding: 0;
   list-style-type: none;
-}
-
-article {
-  ul, ol {
-    padding-left: 2em;
-    margin: {
-      top: 2em;
-      bottom: 2em;
-    }
-    li {
-      line-height: $base-line-height;
-      margin: {
-        top: 1em;
-        bottom: 1em;
-      }
-    }
-  }
-  ul {
-    list-style-type: square;
-  }
-  ol {
-    list-style-type: decimal;
+  li {
+    margin: 0;
   }
 }

--- a/assets/_scss/elements/_list.scss
+++ b/assets/_scss/elements/_list.scss
@@ -21,7 +21,7 @@ article {
     }
   }
   ul {
-    list-style-type: disc;
+    list-style-type: square;
   }
   ol {
     list-style-type: decimal;

--- a/assets/_scss/elements/_list.scss
+++ b/assets/_scss/elements/_list.scss
@@ -21,7 +21,7 @@ ol {
 
 // Unstyled lists
 
-.unstyled-list {
+.usa-unstyled-list {
   margin: 0;
   padding: 0;
   list-style-type: none;

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -23,6 +23,10 @@ a {
   }
 }
 
+.usa-display {
+  font-size: $title-font-size;
+}
+
 h1, h2, h3, h4, h5, h6 {
   clear: both;
   margin: {

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -23,20 +23,6 @@ a {
   }
 }
 
-.sans {
-  font-family: $font-sans;
-}
-
-.usa-link {
-  border-bottom: none;
-  font-family: $font-sans; 
-  font-weight: $font-bold;
-}
-
-.usa-display {
-  font-size: $title-font-size;
-}
-
 h1, h2, h3, h4, h5, h6 {
   clear: both;
   margin: {
@@ -109,4 +95,20 @@ h5 {
 
 h6 {
   @include h6();
+}
+
+// Custom typography
+
+.sans {
+  font-family: $font-sans;
+}
+
+.usa-link {
+  border-bottom: none;
+  font-family: $font-sans; 
+  font-weight: $font-bold;
+}
+
+.usa-display {
+  font-size: $title-font-size;
 }

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -103,7 +103,7 @@ h6 {
   font-family: $font-sans;
 }
 
-.usa-link {
+.sans a {
   border-bottom: none;
   font-family: $font-sans; 
   font-weight: $font-bold;

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -26,7 +26,7 @@ a {
 .usa-link {
   border-bottom: none;
   font-family: $font-sans; 
-  font-weight: 700;
+  font-weight: $font-bold;
 }
 
 .usa-display {

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -18,13 +18,19 @@ p {
 
 a {
   color: $color-base-link;
+  border-bottom: 1px dotted;
   &:hover, &:active, &:visited {
     color: $color-base-link;
+  }
+  &:hover {
+    border-bottom: 1px solid;
   }
 }
 
 .usa-link {
+  border-bottom: none;
   font-family: $font-sans; 
+  font-weight: 700;
 }
 
 .usa-display {

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -50,37 +50,37 @@ h5 {
 
 @mixin title {
   font-size: $title-font-size;
-  font-weight: 700;
+  font-weight: $font-bold;
 }
 
 @mixin h1 {
   font-size: $h1-font-size;
-  font-weight: 700;
+  font-weight: $font-bold;
 }
 
 @mixin h2 {
   font-size: $h2-font-size;
-  font-weight: 700;
+  font-weight: $font-bold;
 }
 
 @mixin h3 {
   font-size: $h3-font-size;
-  font-weight: 700;
+  font-weight: $font-bold;
 }
 
 @mixin h4 {
   font-size: $h4-font-size;
-  font-weight: 700;
+  font-weight: $font-bold;
 }
 
 @mixin h5 {
   font-size: $h5-font-size;
-  font-weight: 700;
+  font-weight: $font-bold;
 }
 
 @mixin h6 {
   font-size: $h6-font-size;
-  font-weight: 700;
+  font-weight: $font-bold;
 }
 
 h1 {

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -32,6 +32,10 @@ h1, h2, h3, h4, h5, h6 {
   line-height: $heading-line-height;
 }
 
+h5 {
+  text-transform: uppercase;
+}
+
 // Create heading mixins 
 
 @mixin title {

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -23,6 +23,10 @@ a {
   }
 }
 
+.usa-link {
+  font-family: $font-sans; 
+}
+
 .usa-display {
   font-size: $title-font-size;
 }

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -18,7 +18,7 @@ p {
 
 a {
   border-bottom: 1px dotted;
-  
+
   &:hover {
     border-bottom: 1px solid;
   }

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -17,10 +17,10 @@ p {
 }
 
 a {
-  color: $color-base-link;
+  color: $color-primary;
   border-bottom: 1px dotted;
   &:hover, &:active, &:visited {
-    color: $color-base-link;
+    color: $color-primary-darker;
   }
   &:hover {
     border-bottom: 1px solid;

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -99,11 +99,11 @@ h6 {
 
 // Custom typography
 
-.sans {
+.usa-sans {
   font-family: $font-sans;
 }
 
-.sans a {
+.usa-sans a {
   border-bottom: none;
   font-family: $font-sans; 
   font-weight: $font-bold;

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -17,11 +17,7 @@ p {
 }
 
 a {
-  color: $color-primary;
   border-bottom: 1px dotted;
-  &:hover, &:active, &:visited {
-    color: $color-primary-darker;
-  }
   &:hover {
     border-bottom: 1px solid;
   }

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -18,6 +18,7 @@ p {
 
 a {
   border-bottom: 1px dotted;
+  
   &:hover {
     border-bottom: 1px solid;
   }

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -23,6 +23,10 @@ a {
   }
 }
 
+.sans {
+  font-family: $font-sans;
+}
+
 .usa-link {
   border-bottom: none;
   font-family: $font-sans; 

--- a/assets/_scss/themes/_usa.scss
+++ b/assets/_scss/themes/_usa.scss
@@ -1,6 +1,7 @@
 // Colors
-$color-main:        #0071bc;
-$color-main-dark:   #00609f;
+
+$color-primary:        #0071bc;
+$color-primary-darker:   #00609f;
 
 
 // Magic Numbers
@@ -16,13 +17,13 @@ li {
 }
 
 a {
-  color: $color-main;
+  color: $color-primary;
   text-decoration: none;
   &:hover, &:active {
-    color: $color-main-dark;
+    color: $color-primary-darker;
   }
   &:visited {
-    color: $color-main;
+    color: $color-primary;
   }
 }
 
@@ -34,7 +35,7 @@ button[type="button"],
 button[type="submit"],
 button[type="reset"] {
   color: #fff;
-  background-color: $color-main;
+  background-color: $color-primary;
   border-radius: $border-radius;
   font-family: $font-sans;  
 }
@@ -46,7 +47,7 @@ input[type="image"]:hover,
 button[type="button"]:hover,
 button[type="submit"]:hover,
 button[type="reset"]:hover {
-  background-color: $color-main-dark; 
+  background-color: $color-primary-darker; 
 }
 
 input[type="text"],
@@ -68,7 +69,7 @@ textarea {
 
 aside {
   color: #fff;
-  background-color: $color-main;
+  background-color: $color-primary;
 }
 
 // Site Patterns
@@ -88,7 +89,7 @@ aside {
   background-color: #fff;
   border-bottom: 1px solid $color-grey-300;
   h1 {
-    color: $color-main;
+    color: $color-primary;
   }
   .site-search {
     input[type="search"] {

--- a/assets/_scss/themes/_usa.scss
+++ b/assets/_scss/themes/_usa.scss
@@ -11,17 +11,18 @@ $border-radius: rem(4px);
 
 // Elements
 
-p,
-li {
+p, li {
   font-family: $font-serif;
 }
 
 a {
   color: $color-primary;
   text-decoration: none;
+
   &:hover, &:active {
     color: $color-primary-darker;
   }
+
   &:visited {
     color: $color-primary;
   }
@@ -79,6 +80,7 @@ aside {
     border-top-right-radius: 0px;
     border-bottom-right-radius: 0px;
   }
+
   input[type="submit"] {
     border-top-left-radius: 0px;
     border-bottom-left-radius: 0px;
@@ -88,9 +90,11 @@ aside {
 .global-header {
   background-color: #fff;
   border-bottom: 1px solid $color-grey-300;
+
   h1 {
     color: $color-primary;
   }
+
   .site-search {
     input[type="search"] {
       border: 1px solid $color-grey-200;

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -192,9 +192,6 @@ header[role="banner"] {
     }
     a {
       text-decoration: none;
-      &:hover {
-        text-decoration: underline;
-      }
     }
   }
 }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -191,7 +191,12 @@ header[role="banner"] {
       }
     }
     a {
-      text-decoration: none;
+      text-decoration: 0px;
+      border-bottom: none;
+      &:hover {
+        border-bottom: 1px solid;
+        color: $color-primary-darker;
+      }
     }
   }
 }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -47,7 +47,10 @@ a#skipnav {
 
 header[role="banner"] {
   background-color: $color-grey-900;
-  a { color: white; }
+  a {
+    border-bottom: none;
+    color: white;
+  }
   nav {
     height: 45px;
     line-height: 45px;
@@ -81,11 +84,11 @@ header[role="banner"] {
     font-size: $base-font-size / 1.25;
     border-bottom: 1px solid $color-grey-700;
     font-weight: 100;
-    a { text-decoration: underline; }
     .us-official { 
       margin: 0;
     }
-    .stage { 
+    .stage {
+      a { text-decoration: underline; }
       float: none;
       display: block;
       padding-top: 5px;
@@ -191,7 +194,6 @@ header[role="banner"] {
       }
     }
     a {
-      text-decoration: 0px;
       border-bottom: none;
       &:hover {
         border-bottom: 1px solid;

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -8,7 +8,7 @@
 @import 'core/grid-settings';
 @import 'core/defaults';
 @import 'core/utilities';
-
+@import 'themes/usa';
 
 // Variables -------------- //
 
@@ -177,7 +177,7 @@ header[role="banner"] {
       margin: 0;
     }  
     ul {
-      color: $color-main;      
+      color: $color-primary;      
       ul {
         display: none;
         padding: 0;        


### PR DESCRIPTION
This adds the typography live content to the library: headings, body text, links, and lists.

Note: 

- Some of these can be considered "elements" (HTML elements) and may be able to be moved into their own file. We'll need further research on this. Currently, everything is in located in `typography.md` and `_typography.scss`.
- I'm using ems for the margins on headings so it scales with the font being used. You'll see larger margins for larger fonts, smaller margins for smaller fonts.
- Body text is not using the 500px max-width as I will consider the best approach to do this. We want users not to be restricted when adding in body text if they don't need the constraint. For example, they may need longer space for text for a hero image.
- This does not add in Example

This is what it looks like:
![typography](https://cloud.githubusercontent.com/assets/5249443/8421319/aacfd52e-1e81-11e5-865d-75716e74334b.png)