### PR TITLE
[WIP] Add visual tweaks

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -17,7 +17,7 @@
         <h1>Government Wide Pattern Library</h1>
       </a>
     </div>
-    <ul>
+    <ul class="usa-unstyled-list">
       <li>
         <a href="{{ site.baseurl }}/about/">About</a>
       </li>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -19,7 +19,9 @@ title: Typography
   <!-- Body title -->
   <h3>Body</h3>
 
-  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+  <div class="usa-content">
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+  </div>
 
   <!-- Links title -->
   <h3>Links</h3>

--- a/assets/_scss/elements/_buttons.scss
+++ b/assets/_scss/elements/_buttons.scss
@@ -83,6 +83,7 @@ input[type="image"].usa-button-outlined {
   background-color: $color-white;
   border: 2px solid $color-grey-900;  
   color: $color-grey-900;
+  padding: .8rem 1.8rem;
 }
 
 .usa-button-big,

--- a/assets/_scss/elements/_list.scss
+++ b/assets/_scss/elements/_list.scss
@@ -8,8 +8,8 @@ ul, ol {
   li {
     line-height: $base-line-height;
     margin: {
-      top: .3em;
-      bottom: .3em;
+      top: .75em;
+      bottom: .75em;
     }
   }
 }

--- a/assets/_scss/elements/_list.scss
+++ b/assets/_scss/elements/_list.scss
@@ -17,6 +17,7 @@ ul, ol {
   list-style: none;
   padding-left: 0;
   display: table;
+
   li:after {
     content: "";
     display: block;
@@ -26,6 +27,7 @@ ul, ol {
 
 ul li {
   display: table-row;
+
   &:before {
     content: "•";
     display: table-cell;
@@ -36,6 +38,7 @@ ul li {
 ol li {
   display: table-row;
   counter-increment: table-ol;
+  
   &:before {
     content: counter(table-ol) ".";
     display: table-cell;

--- a/assets/_scss/elements/_list.scss
+++ b/assets/_scss/elements/_list.scss
@@ -2,7 +2,6 @@ ul, ol {
   margin: {
     top: 2em;
     bottom: 2em;
-  padding-left: 2em;
   }
 
   li {
@@ -16,10 +15,12 @@ ul, ol {
 
 ul {
   list-style-type: square;
+  padding-left: 1.1em;
 }
 
 ol {
   list-style-type: decimal;
+  padding-left: 1.4em;
 }
 
 // Unstyled lists

--- a/assets/_scss/elements/_list.scss
+++ b/assets/_scss/elements/_list.scss
@@ -8,8 +8,8 @@ ul, ol {
   li {
     line-height: $base-line-height;
     margin: {
-      top: 1em;
-      bottom: 1em;
+      top: .3em;
+      bottom: .3em;
     }
   }
 }

--- a/assets/_scss/elements/_list.scss
+++ b/assets/_scss/elements/_list.scss
@@ -13,14 +13,39 @@ ul, ol {
   }
 }
 
-ul {
-  list-style-type: square;
-  padding-left: 1.1em;
+ul, ol {
+  list-style: none;
+  padding-left: 0;
+  display: table;
+  li:after {
+    content: "";
+    display: block;
+    margin-bottom: 0.5em;
+  }
 }
 
-ol {
-  list-style-type: decimal;
-  padding-left: 1.4em;
+ul li {
+  display: table-row;
+  &:before {
+    content: "•";
+    display: table-cell;
+    padding-right: 0.4em;
+  }
+}
+
+ol li {
+  display: table-row;
+  counter-increment: table-ol;
+  &:before {
+    content: counter(table-ol) ".";
+    display: table-cell;
+    padding-right: 0.4em;
+    text-align: right;
+  }
+}
+
+li {
+  margin-bottom: 0.5em;
 }
 
 // Unstyled lists
@@ -32,5 +57,10 @@ ol {
   
   li {
     margin: 0;
+
+    &:before {
+      content: "";
+      padding-right: 0;
+    }
   }
 }

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -100,6 +100,14 @@ h6 {
 
 // Custom typography
 
+.usa-content {
+  > p, 
+  > ul, 
+  > ol {
+    max-width: 50rem;
+  }  
+}
+
 .usa-sans {
   font-family: $font-sans;
 }

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -101,9 +101,7 @@ h6 {
 // Custom typography
 
 .usa-content {
-  > p, 
-  > ul, 
-  > ol {
+  > p, > ul, > ol {
     max-width: 50rem;
   }  
 }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -29,7 +29,7 @@ $width-nav-sidebar: 250px;
 a#skipnav {
   padding: 10px 15px;
   position: absolute;
-  top: -40px;
+  top: -42px;
   left: 0px;
   color: $color-grey-900;
   background: transparent;

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -152,7 +152,7 @@ header[role="banner"] {
 
 .sidenav {
   position: absolute;
-  top: 83px;
+  top: 73px;
   bottom: 0;
   left: 0;
   width: $width-nav-sidebar;
@@ -228,7 +228,7 @@ header[role="banner"] {
 
 .main-content {
   position: absolute;
-  top: 83px;
+  top: 73px;
   bottom: 0;
   right: 0;
   overflow: auto;

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -252,7 +252,7 @@ header[role="banner"] {
   position: relative;
   padding: 0 2em 1em 2em;
   > h2, > h3, > p, > ul, > ol {
-    max-width: 500px;
+    max-width: 50rem;
   }
   > h1 {
     border-bottom: 1px solid #000;

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -175,6 +175,7 @@ header[role="banner"] {
       font-size: $h4-font-size;
       font-weight: bold;
       margin: 0;
+      padding-bottom: .2em;
     }
     h3 {
       margin: 0;
@@ -185,7 +186,16 @@ header[role="banner"] {
         display: none;
         padding: 0;        
         li {
-          padding-left: 1em;          
+          line-height: 1.8em;
+          padding-left: 1em;
+
+          &:before {
+            content: "";
+            padding-right: 1em;
+          }
+          &:after {
+            margin-bottom: 0;
+          }
         }
       }
       li {

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -78,7 +78,7 @@ header[role="banner"] {
   }
 
   .disclaimer {
-    padding: 10px 20px;
+    padding: .5rem 2rem;
     color: white;
     text-align: center;
     font-size: $base-font-size / 1.25;


### PR DESCRIPTION
This implements various fixes:

- fixes main nav links by adding unstyled list class (was dropped below navbar)
- makes disclaimer bar shorter and uses rem
- moves skipnav up 2px so it doesn’t show
- adds max width 50rem (500px) for p text used within `usa-content` class. Utilizing the cascade here bc doesn’t make sense to apply a class for such a commonly used element. Idea for nesting this from CFPB.
- reduces size of outline button by .2rem (2px) all around bc border was making it larger. This makes outline button the same size as the rest.