### PR TITLE
Updating styles to remove scroll bars from code snippets.

### DIFF
--- a/_components/accordions.md
+++ b/_components/accordions.md
@@ -144,13 +144,13 @@ title: Accordions
 }
 
 #accordion-menu ul li.hidden p {
-  background: url("../img/arrow-right.png") no-repeat;
+  background: url("https://raw.githubusercontent.com/18F/govt-wide-patternlibrary/18f-pages-staging/assets/img/arrow-right.png") no-repeat;
   background-position: 15px;
   border-bottom: 0; 
 }
 
 #accordion-menu ul li p {
-  background: url("../img/arrow-down.png") no-repeat;
+  background: url("https://raw.githubusercontent.com/18F/govt-wide-patternlibrary/18f-pages-staging/assets/img/arrow-down.png") no-repeat;
   background-position: 15px;
   border-bottom: 1px solid #757575;
   color: #212121;

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -319,6 +319,9 @@ header[role="banner"] {
         top: 0;
         margin: 0;
         border-radius: 0;
+        &:hover {
+          background-color: $color-grey-900;
+        }
       }
     }
     th {

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -312,10 +312,13 @@ header[role="banner"] {
       background-color: $color-grey-100;
       border: 1px solid $color-grey-300;
       position: relative;
+      vertical-align: top;
       .code-copy-button {
         position: absolute;
         right: 0;
         top: 0;
+        margin: 0;
+        border-radius: 0;
       }
     }
     th {
@@ -331,14 +334,10 @@ header[role="banner"] {
     }
     pre {
       padding: 0 1em 1em 1em;
-      overflow: auto;
-      height: 300px;
     }
     code {
       font-size: $base-font-size / 1.5;
       line-height: 1.4em;
-      overflow: scroll;
-      max-height: 25em;
       &.language-html {
         max-width: 25em;
         word-wrap: break-word;


### PR DESCRIPTION
Per feedback from the UX/Visual Design team, there are a few small tweaks to the code snippets. The vertical scroll bars have been removed and the "Copy" button has been re-styled.

I've also added in an absolute reference to the arrow images for now for the accordion, as we still have not come to a final conclusion for using Font Awesome vs... ?? would rather do this for now and fix as we come to a solve.

Screenshots below of the design fixes:

![screen shot 2015-07-07 at 3 59 32 pm](https://cloud.githubusercontent.com/assets/955558/8555829/997b2dec-24c0-11e5-8249-c70da486d100.png)
