### PR TITLE
Add full-width buttons on small screens

### DIFF
--- a/assets/_scss/components/_footer.scss
+++ b/assets/_scss/components/_footer.scss
@@ -1,13 +1,4 @@
 .usa-footer {
-
-  button {
-    width: 100%;
-  
-    @media (min-width: $tablet-up) {
-      width: auto;
-    }
-  }
-
   .usa-unstyled-list {
     display: block;
   }

--- a/assets/_scss/elements/_buttons.scss
+++ b/assets/_scss/elements/_buttons.scss
@@ -25,6 +25,7 @@ input[type="image"] {
   padding: 1rem 2rem;
   text-align: center;
   text-transform: capitalize;
+  width: 100%;
   -webkit-font-smoothing: antialiased;
 
   &:hover,
@@ -40,6 +41,10 @@ input[type="image"] {
   &.usa-button-active {
     background-color: $color-base-link;
   }
+
+  @media (min-width: $mobile-up) {
+    width: auto;
+  }  
 }
 
 input[type="submit"]:disabled,


### PR DESCRIPTION
This adds full width buttons on small screens and leaves it normal width on larger screens. This will be the default behavior and apply to all button elements and and button inputs.

This is what it looks like:

**Small screens:**

<img width="394" alt="screen shot 2015-07-16 at 12 59 29 pm" src="https://cloud.githubusercontent.com/assets/5249443/8733828/c8151ee6-2bba-11e5-8354-f77b0007437c.png">


**Large screens:**

<img width="426" alt="screen shot 2015-07-16 at 1 00 13 pm" src="https://cloud.githubusercontent.com/assets/5249443/8733832/ccacfa46-2bba-11e5-919b-8c561b53b9bd.png">