### PR TITLE
Add address form fixes

### DIFF
--- a/_components/form-blocks.md
+++ b/_components/form-blocks.md
@@ -81,7 +81,7 @@ title: Forms Blocks
         </div>
       </div>
 
-      <label for="zip">Zip</label>
+      <label for="zip">ZIP</label>
       <input class="usa-input-medium" id="zip" name="zip" type="text" pattern="[\d]{5}(-[\d]{4})">
       </fieldset>
 

--- a/assets/_scss/components/_forms.scss
+++ b/assets/_scss/components/_forms.scss
@@ -118,9 +118,9 @@ input.usa-input-medium {
 }
 
 .usa-input-dropdown {
+  appearance: none;  
   background: url("../img/arrow-down.png") no-repeat;
   background-position: right 1.3rem center;
-  -webkit-appearance:none;
 }
 
 .usa-additional_text {


### PR DESCRIPTION
This capitalizes the ZIP label which was brought up: https://trello.com/c/WrifB2BI/210-address-block

This also changes `-webkit-appearance` to `appearance` used on the select input.

This is what it looks like:

![screen shot 2015-07-17 at 11 09 04 am](https://cloud.githubusercontent.com/assets/5249443/8753898/2bc769da-2c74-11e5-90bf-27b7e516d1dc.png)