### PR TITLE
Sign in styling fixes

### DIFF
--- a/_components/form-blocks.md
+++ b/_components/form-blocks.md
@@ -134,7 +134,7 @@ title: Forms Blocks
       <input id="username" name="username" type="text">
 
       <label for="password">Password</label>
-      <input id="password" name="password" type="text">
+      <input id="password" name="password" type="password">
       <p class="usa-form-note">
         <a title="Show password" href="javascript:void(0)"
             class="usa-show_password"

--- a/assets/_scss/components/_forms.scss
+++ b/assets/_scss/components/_forms.scss
@@ -30,6 +30,7 @@ form {
 
 .usa-form-note {
   float: right;
+  font-family: $font-sans;
   font-size: $small-font-size;
   margin: 0;
   margin-bottom: 1.5rem;

--- a/assets/_scss/core/_variables.scss
+++ b/assets/_scss/core/_variables.scss
@@ -1,7 +1,7 @@
 // Typography
 $em-base:       10px;
 $base-font-size:    rem(16px);
-$small-font-size:   rem(12px);
+$small-font-size:   rem(14px);
 $title-font-size:   rem(48px);
 $h1-font-size:      rem(36px);
 $h2-font-size:      rem(24px);

--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -86,7 +86,6 @@ $(function() {
         $(this).parent().removeClass('hidden')
         .siblings().addClass('hidden');
       });
-      
     } else {
 
       $('.usa-footer-big nav ul').removeClass('hidden');


### PR DESCRIPTION
Sets the password field to default to password, changes "show password" to sans as asked by design team, increases font size on that sans font a bit because it was looking really small.