### PR TITLE
Remove sample component from index.html

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -14,23 +14,6 @@ title: Government Wide Pattern Library
 
 <p>The US Government web pattern library project is a partnership of the <a href="https://whitehouse.gov/usds">U.S. Digital Service</a> and <a href="https://18f.gsa.gov">18F</a> with the support of partners across the Federal Government. If you'd like to learn more, please send a note to <a href="mailto:govtwidepatternlibrary@gsa.gov">govtwidepatternlibrary@gsa.gov</a>.</p>
 
-<h1>Component name</h1>
-
-<div class="preview">
-<!-- Add HTML markup for example here -->
-</div>
-
-<div class="usa-grid-box">
-  <div class="usa-width-one-half">
-    <h3>Use</h3>
-    <p>This is where you'll find basic guidelines about the usage of a component. For example, a minimal palette, clear hierarchy, good information design, and ample whitespace will ensure a voice of authority and expertise in communication.</p>
-  </div>
-  <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
-    <p>Accessibility is one of the most important aspects of modern web development. Accessibility means the greatest number of users can view your content.</p>
-  </div>  
-</div> 
-
 <h1>Visual Style</h1>
 
 {% for visual in site.visual %}


### PR DESCRIPTION
This removes the sample component from index.html. It was put in as a placeholder originally and not needed. 