### PR TITLE
Add pointer cursor to checkbox and radio inputs

### DIFF
--- a/assets/_scss/elements/_inputs.scss
+++ b/assets/_scss/elements/_inputs.scss
@@ -82,6 +82,7 @@ input[type="radio"] {
 
 input[type="checkbox"] + label,
 input[type="radio"] + label {
+  cursor: pointer;
   font-weight: 400;
   margin-bottom: 0.5em;
 }


### PR DESCRIPTION
This adds the pointer cursor to checkbox and radio inputs in order to indicate that you can click on them.

This resolves #254. 