### PR TITLE
Add top margin to labels

### DIFF
--- a/assets/_scss/elements/_labels.scss
+++ b/assets/_scss/elements/_labels.scss
@@ -3,6 +3,7 @@
   border-radius: $border-radius;
   color: $color-white;
   font-size: $small-font-size;
+  margin-right: .1em;
   padding: {
     bottom: 0.1rem;
     left: 0.7rem;

--- a/assets/_scss/elements/_labels.scss
+++ b/assets/_scss/elements/_labels.scss
@@ -8,7 +8,7 @@
     bottom: 0.1rem;
     left: 0.7rem;
     right: 0.7rem;
-    top: 0.1rem;
+    top: 0.3rem;
   }
   text-transform: uppercase;
 }

--- a/assets/_scss/elements/_labels.scss
+++ b/assets/_scss/elements/_labels.scss
@@ -3,7 +3,6 @@
   border-radius: $border-radius;
   color: $color-white;
   font-size: $small-font-size;
-  margin-right: .1em;
   padding: {
     bottom: 0.1rem;
     left: 0.7rem;


### PR DESCRIPTION
This adds more margin on the top of the label so it's the same amount of space above and below. There's more space on the bottom bc of descenders in the font. Since we're using uppercase font, this evens it out.

This also adds a little more margin to the right in case several labels are side by side.

This is what it looks like:
<img width="103" alt="screen shot 2015-08-04 at 4 16 56 pm" src="https://cloud.githubusercontent.com/assets/5249443/9074963/71e85c5e-3ac4-11e5-8f0d-fc53d573b236.png">