### PR TITLE
Change grid class naming

### DIFF
--- a/_components/accordions.md
+++ b/_components/accordions.md
@@ -56,7 +56,7 @@ title: Accordions
   </ul>
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <ul>

--- a/_components/alerts.md
+++ b/_components/alerts.md
@@ -43,7 +43,7 @@ title: Alerts
 
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <p>This is the usage content for the example.</p>

--- a/_components/footers.md
+++ b/_components/footers.md
@@ -9,11 +9,11 @@ title: Footers
   <h3>Footer Big</h3>
 
   <footer class="usa-footer usa-footer-big usa-sans" role="contentinfo">
-    <div class="usa-grid-box usa-footer-return-to-top">
+    <div class="usa-grid usa-footer-return-to-top">
       <a href="#">Return to top</a>
     </div>
     <div class="usa-footer-primary-section">
-      <div class="usa-grid-box-full">
+      <div class="usa-grid-full">
         <nav class="usa-footer-nav usa-width-two-thirds">
           <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
             <h3 class="usa-footer-primary-link">Topic</h3>
@@ -57,7 +57,7 @@ title: Footers
     </div>
 
     <div class="usa-footer-secondary_section usa-footer-big-secondary-section">
-      <div class="usa-grid-box">
+      <div class="usa-grid">
         <div class="usa-footer-logo usa-width-one-half">
           <img class="usa-footer-logo-img" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
           <h3 class="usa-footer-logo-heading">Name of Agency</h3>
@@ -104,11 +104,11 @@ title: Footers
   <h3>Footer Medium</h3>
 
   <footer class="usa-footer usa-footer-medium usa-sans" role="contentinfo">
-    <div class="usa-grid-box usa-footer-return-to-top">
+    <div class="usa-grid usa-footer-return-to-top">
       <a href="#">Return to top</a>
     </div>
     <div class="usa-footer-primary-section">
-      <div class="usa-grid-box-full">
+      <div class="usa-grid-full">
         <nav class="usa-footer-nav">
           <ul class="usa-unstyled-list">
             <li class="usa-width-one-sixth usa-footer-primary-content">
@@ -132,7 +132,7 @@ title: Footers
     </div>
 
     <div class="usa-footer-secondary_section">
-      <div class="usa-grid-box">
+      <div class="usa-grid">
         <div class="usa-footer-logo usa-width-one-half">
           <img class="usa-footer-logo-img" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
           <h3 class="usa-footer-logo-heading">Name of Agency</h3>
@@ -179,11 +179,11 @@ title: Footers
   <h3>Footer Slim</h3>
 
   <footer class="usa-footer usa-footer-slim usa-sans" role="contentinfo">
-    <div class="usa-grid-box usa-footer-return-to-top">
+    <div class="usa-grid usa-footer-return-to-top">
       <a href="#">Return to top</a>
     </div>
     <div class="usa-footer-primary-section">
-      <div class="usa-grid-box-full">
+      <div class="usa-grid-full">
         <nav class="usa-footer-nav usa-width-two-thirds">
           <ul class="usa-unstyled-list">
             <li class="usa-width-one-fourth usa-footer-primary-content">
@@ -210,7 +210,7 @@ title: Footers
     </div>
 
     <div class="usa-footer-secondary_section">
-      <div class="usa-grid-box">
+      <div class="usa-grid">
         <div class="usa-footer-logo">
           <img class="usa-footer-slim-logo-img" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
           <h3 class="usa-footer-slim-logo-heading">Name of Agency</h3>
@@ -230,7 +230,7 @@ title: Footers
 
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <ul>

--- a/_components/form-blocks.md
+++ b/_components/form-blocks.md
@@ -101,7 +101,7 @@ title: Forms Blocks
 
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <p>As you customize this form, ensure it continues to:</p>
@@ -149,7 +149,7 @@ title: Forms Blocks
 
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <ul>
@@ -193,7 +193,7 @@ title: Forms Blocks
   </form>
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <ul>
@@ -246,7 +246,7 @@ title: Forms Blocks
 
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <ul>
@@ -313,7 +313,7 @@ title: Forms Blocks
   </form>
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <ul>
@@ -365,7 +365,7 @@ title: Forms Blocks
   
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <ul>

--- a/_components/headers.md
+++ b/_components/headers.md
@@ -9,7 +9,7 @@ title: Headers & Navigation
   <img src="{{ site.baseurl }}/assets/img/static/HeaderNav_FullUI_v1-930width.png">
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <p>This is the usage content for the example.</p>

--- a/_components/search-bar.md
+++ b/_components/search-bar.md
@@ -6,7 +6,7 @@ title: Search Bar
 
 <div class="preview preview-search-bar">
 
-  <div class="usa-grid-box">
+  <div class="usa-grid">
     <div class="usa-width-one-half">
       <form class="usa-search usa-search-big">           
         <fieldset>
@@ -23,7 +23,7 @@ title: Search Bar
     </div>
   </div>
 
-  <div class="usa-grid-box">
+  <div class="usa-grid">
     <div class="usa-width-one-third">
       <form class="usa-search usa-search-medium">           
         <fieldset>
@@ -40,7 +40,7 @@ title: Search Bar
     </div>
   </div>
 
-  <div class="usa-grid-box">
+  <div class="usa-grid">
     <div class="usa-width-one-fourth">  
       <form class="usa-search usa-search-small">           
         <fieldset>
@@ -59,7 +59,7 @@ title: Search Bar
   
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <ul>

--- a/_components/search-results.md
+++ b/_components/search-results.md
@@ -9,7 +9,7 @@ title: Search Results
   <img src="{{ site.baseurl }}/assets/img/static/Search_Results_UI_v1.png">
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <p>This is the usage content for the example.</p>

--- a/_elements/buttons.md
+++ b/_elements/buttons.md
@@ -31,7 +31,7 @@ title: Buttons
 
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <p>This is the usage content for the example.</p>

--- a/_elements/inputs.md
+++ b/_elements/inputs.md
@@ -121,7 +121,7 @@ title: Inputs
   <img src="{{ site.baseurl }}/assets/img/static/Date_Picker_UI_v1.png">
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <p>This is the usage content for the example.</p>

--- a/_elements/labels.md
+++ b/_elements/labels.md
@@ -14,7 +14,7 @@ title: Labels
 
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <p>This is the usage content for the example.</p>

--- a/_elements/tables.md
+++ b/_elements/tables.md
@@ -96,7 +96,7 @@ title: Tables
 
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <p>This is the usage content for the example.</p>

--- a/_layout-system/grids.md
+++ b/_layout-system/grids.md
@@ -6,7 +6,7 @@ title: Grids
 <div class="preview">
 
   <h3>Grid</h3>
-  <div class="usa-grid-box usa-grid-box-example usa-grid-box-example-blank">
+  <div class="usa-grid usa-grid-example usa-grid-example-blank">
     <div class="usa-width-one-whole">1/1</div>
     <div class="usa-width-one-half">1/2</div>
     <div class="usa-width-one-half usa-end-row">1/2</div>
@@ -38,7 +38,7 @@ title: Grids
   </div>
 
   <h3>Grid Examples</h3>
-  <div class="usa-grid-box usa-grid-box-example usa-grid-box-text">
+  <div class="usa-grid usa-grid-example usa-grid-text">
     <div class="usa-width-one-half">
       <h3>One Half</h3>
       <p>Synth polaroid occupy ennui sustainable, craft beer chambray viral church-key typewriter letterpress McSweeney's Etsy. Banh mi Brooklyn single-origin coffee, meditation swag sriracha artisan disrupt cliche sustainable selfies wayfarers. Hoodie iPhone occupy you probably haven't heard of them synth seitan four loko kale chips, wayfarers salvia literally. Squid sartorial fixie yr, retro normcore banjo hella typewriter cray lomo asymmetrical post-ironic mustache pickled. Ennui roof party health goth, next level Etsy letterpress polaroid mixtape.</p>
@@ -99,7 +99,7 @@ title: Grids
 
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <p>This is the usage content for the example.</p>

--- a/_layout-system/layouts.md
+++ b/_layout-system/layouts.md
@@ -8,7 +8,7 @@ title: Layouts
   <img src="{{ site.baseurl }}/assets/img/static/Layouts_UI_v1.png">  
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <p>This is the usage content for the example.</p>

--- a/_visual/colors.md
+++ b/_visual/colors.md
@@ -8,7 +8,7 @@ title: Colors
   <img src="{{ site.baseurl }}/assets/img/static/Colors_UI_v1.png">
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <p>This is the usage content for the example.</p>

--- a/_visual/icons.md
+++ b/_visual/icons.md
@@ -9,7 +9,7 @@ title: Icons
   <img src="{{ site.baseurl }}/assets/img/static/Icons_v1.png">
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <p>This is the usage content for the example.</p>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -64,7 +64,7 @@ title: Typography
   </div>
 </div>
 
-<div class="usa-grid-box">
+<div class="usa-grid">
   <div class="usa-width-one-half">
     <h3>Use</h3>
     <p>This is the usage content for the example.</p>

--- a/assets/_scss/components/_footer.scss
+++ b/assets/_scss/components/_footer.scss
@@ -51,7 +51,7 @@
     }  
   }
 
-  .usa-grid-box-full {
+  .usa-grid-full {
     @media (min-width: $tablet-up) {
       padding: {
         left: 2.5rem;
@@ -102,7 +102,7 @@
         top: 1rem;
       }
 
-      .usa-grid-box-full {
+      .usa-grid-full {
         align-items: center;
         display: flex;     
       }      

--- a/assets/_scss/core/_grid.scss
+++ b/assets/_scss/core/_grid.scss
@@ -1,5 +1,5 @@
-.usa-grid-box,
-.usa-grid-box-full {
+.usa-grid,
+.usa-grid-full {
   @include outer-container();
   max-width: $site-max-width;
 
@@ -38,10 +38,10 @@
   }
 }
 
-.usa-grid-box {
+.usa-grid {
   padding: 0 $grid-margins;
 }
 
-.usa-grid-box-full {
+.usa-grid-full {
   padding: 0;
 }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -381,14 +381,14 @@ header[role="banner"] {
 // Search bar grid --------- //
 
 .preview-search-bar {
-  .usa-grid-box {
+  .usa-grid {
     padding: 0;
   }
 }
 
 // Custom styles to illustrate invisible grid for pattern library
 
-.usa-grid-box-example {
+.usa-grid-example {
   background: $color-grid-light;
 
   > * {
@@ -411,11 +411,11 @@ header[role="banner"] {
   }
 }
 
-.usa-grid-box-example-blank {
+.usa-grid-example-blank {
   text-align: center;
 }
 
-.usa-grid-box-text {
+.usa-grid-text {
   background: $color-grid-dark;
 
   > * {


### PR DESCRIPTION
This changes our grid class naming convention from `usa-grid-box` to `usa-grid`.

This resolves #265.