### PR TITLE
A quick implementation of autoprefixer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gem 'jekyll'
 
 gem 'rouge'
 gem 'redcarpet'
+gem 'octopress-autoprefixer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    autoprefixer-rails (2.2.0.20140804)
+      execjs
     blankslate (2.1.2.4)
     celluloid (0.16.0)
       timers (~> 4.0.0)
@@ -45,6 +47,12 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     mercenary (0.3.5)
+    octopress-autoprefixer (1.0.1)
+      autoprefixer-rails (~> 2.2)
+      jekyll (>= 2.0)
+      octopress-hooks (~> 2.0)
+    octopress-hooks (2.6.1)
+      jekyll (>= 2.0)
     parslet (1.5.0)
       blankslate (~> 2.0)
     posix-spawn (0.3.11)
@@ -69,5 +77,9 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll
+  octopress-autoprefixer
   redcarpet
   rouge
+
+BUNDLED WITH
+   1.10.5

--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,9 @@ sass:
   sass_dir: assets/_scss
 #  style: :compressed
 
+gems:
+- octopress-autoprefixer
+
 collections:
   visual:
     output: true


### PR DESCRIPTION
[Autoprefixer](https://github.com/postcss/autoprefixer) is a tool for automatically adding browser prefixes to CSS code. There are a number of ways to implement the tool, but because we've already got Jekyll in place as our build tool the [`octopress-autoprefixer` gem](https://github.com/octopress/autoprefixer) makes this exceedingly easy to get going.

This PR has the following changes:

0. The gem has been added to the `Gemfile` and `Gemfile.lock`
0. `_config.yml` has been configured to use that gem in the build

No subsequent special behavior is required for the tool to start working, `./go serve` will ensure that `autoprefixer` is used.

This is not the only way to add `autoprefixer` to the project, but it seemed like the easiest to try it out.